### PR TITLE
Add jupyter plugin to black and small fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN set -eux \
 		pip3 install --no-cache-dir --no-compile "black[jupyter]>=${VERSION},<$(echo "${VERSION}+0.1" | bc)"; \
 	fi \
 	\
-	&& black --version | grep -E '^black,\s[0-9][0-9].[0-9].[0-9]+' \
+	&& black --version | grep -E 'black.+?version\s[0-9]+|^black,\s[0-9][0-9].[0-9].[0-9]+' \
 	\
 	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
 	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,12 @@ RUN set -eux \
 ARG VERSION
 RUN set -eux \
 	&& if [ "${VERSION}" = "latest" ]; then \
-		pip3 install --no-cache-dir --no-compile black; \
+		pip3 install --no-cache-dir --no-compile black[jupyter]; \
 	else \
-		pip3 install --no-cache-dir --no-compile "black>=${VERSION},<$(echo "${VERSION}+0.1" | bc)"; \
+		pip3 install --no-cache-dir --no-compile "black[jupyter]>=${VERSION},<$(echo "${VERSION}+0.1" | bc)"; \
 	fi \
 	\
-	&& black --version | grep -E '^black.+?version\s[0-9]+' \
+	&& black --version | grep -E '^black,\s[0-9][0-9].[0-9].[0-9]+' \
 	\
 	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
 	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ _test-version:
 				| sed 's/.*\///g' \
 		)"; \
 		echo "Testing for latest: $${LATEST}"; \
-		if ! docker run --rm $(IMAGE) --version | grep -E "(version)?\s*$${LATEST}$$"; then \
+		if ! docker run --rm $(IMAGE) --version | grep -E "(version)?\s*$${LATEST}"; then \
 			echo "Failed"; \
 			exit 1; \
 		fi; \


### PR DESCRIPTION
Adding the jupyter plugin lets us scan additional files easily.

Also, starting with the production release of black, the version string is different:
```
~# black --version
black, 22.1.0 (compiled: no)
```
I updated the regex to catch that as well as the older beta format.